### PR TITLE
Add httpx

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Find some of those *awesome* packages here and if you are missing one we count o
 *Libraries to build web applications.*
 
 * [aiohttp](https://github.com/KeepSafe/aiohttp) - Http client/server for asyncio (PEP-3156).
+* [httpx](https://github.com/encode/httpx) - the requests-async project grew to become httpx with implementation of both sync and async HTTP client.
 * [sanic](https://github.com/channelcat/sanic) - Python 3.5+ web server that's written to go fast.
 * [Quart](https://gitlab.com/pgjones/quart) - An asyncio web microframework with the same API as Flask.
 * [Vibora](https://github.com/vibora-io/vibora) - Performant web framework inspired by Flask.


### PR DESCRIPTION
Add httpx, a great alternative to aiohttp, although the project is still considered beta.

# What is this project?

Httpx, formerly requests-async is an exciting implementation of async http client with support for HTTP2.

Please add a link in this pull request.

**Note:** Please respect the [Contribution Guidelines](https://github.com/timofurrer/awesome-asyncio/blob/master/CONTRIBUTING.md)!

# Why is it awesome?

* python 3.8 deprecated the practice of passing loop around on parameter list. aiohttp still hasn't been updated and it has some implications which, among other corner cases, makes is difficult to use httpx with pytest-asyncio and pytest-benchmark. Httpx on the other hand works well and knows how to detect the right running loop on its own.
* aiohttp is trying to do too much (client and server) and is becoming bloated. Httpx is only a client and it offers both sync and async versions on the same package.
* httpx has some well known python devs behind it so it should have a promising future.
